### PR TITLE
Fix pending transaction check to avoid redundancy check

### DIFF
--- a/wallet-webapps-common/src/main/java/org/exoplatform/addon/wallet/blockchain/listener/BlockMinedListener.java
+++ b/wallet-webapps-common/src/main/java/org/exoplatform/addon/wallet/blockchain/listener/BlockMinedListener.java
@@ -78,13 +78,6 @@ public class BlockMinedListener extends Listener<Block, Boolean> implements ExoW
             }
           }
         }
-
-        for (TransactionDetail transactionDetail : pendingTransactions) {
-          if (!minedTransactionHashes.contains(transactionDetail.getHash())
-              && (transactionDetail.getRawTransaction() == null || transactionDetail.getSentTimestamp() > 0)) {
-            blockchainTransactionService.checkPendingTransactionValidity(transactionDetail);
-          }
-        }
       }
     } catch (Exception e) {
       LOG.error("Error while checking pending transactions on mined block '{}'", blockNumber, e);


### PR DESCRIPTION
Some checks are added on Block mining event. This PR will move this check to make sure that this check (for transactions marked as pending in internal database) is handled by PendingTransactionVerifierJob process only.