### PR TITLE
Fix retrieving the list of rewards from store

### DIFF
--- a/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/dao/RewardPluginDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/dao/RewardPluginDAO.java
@@ -12,17 +12,19 @@ import org.exoplatform.services.log.Log;
 public class RewardPluginDAO extends GenericDAOJPAImpl<WalletRewardPluginEntity, Long> {
   private static final Log LOG = ExoLogger.getLogger(RewardPluginDAO.class);
 
-  public List<WalletRewardPluginEntity> findRewardPluginsByPeriodId(long rewardId) {
+  public List<WalletRewardPluginEntity> getRewardPluginsByRewardId(long rewardId) {
     TypedQuery<WalletRewardPluginEntity> query = getEntityManager().createNamedQuery("RewardPlugin.getRewardPluginsByRewardId",
                                                                                      WalletRewardPluginEntity.class);
     query.setParameter("rewardId", rewardId);
     return query.getResultList();
   }
 
-  public WalletRewardPluginEntity findRewardPluginByRewardIdAndPlugin(long rewardId, String pluginId) {
-    TypedQuery<WalletRewardPluginEntity> query = getEntityManager().createNamedQuery("RewardPlugin.getRewardPluginsByRewardId",
-                                                                                     WalletRewardPluginEntity.class);
+  public WalletRewardPluginEntity getRewardPluginsByRewardIdAndPluginId(long rewardId, String pluginId) {
+    TypedQuery<WalletRewardPluginEntity> query =
+                                               getEntityManager().createNamedQuery("RewardPlugin.getRewardPluginsByRewardIdAndPluginId",
+                                                                                   WalletRewardPluginEntity.class);
     query.setParameter("rewardId", rewardId);
+    query.setParameter("pluginId", pluginId);
     List<WalletRewardPluginEntity> result = query.getResultList();
     if (result == null || result.isEmpty()) {
       return null;

--- a/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/entity/WalletRewardPluginEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/entity/WalletRewardPluginEntity.java
@@ -14,6 +14,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @Table(name = "ADDONS_WALLET_REWARD_PLUGIN")
 @NamedQueries({
     @NamedQuery(name = "RewardPlugin.getRewardPluginsByRewardId", query = "SELECT rp FROM RewardPlugin rp WHERE rp.reward.id = :rewardId"),
+    @NamedQuery(name = "RewardPlugin.getRewardPluginsByRewardIdAndPluginId", query = "SELECT rp FROM RewardPlugin rp WHERE rp.reward.id = :rewardId AND rp.pluginId = :pluginId"),
 })
 public class WalletRewardPluginEntity implements Serializable {
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/addon/wallet/reward/storage/WalletRewardReportStorage.java
@@ -162,7 +162,7 @@ public class WalletRewardReportStorage implements RewardReportStorage {
 
       for (WalletPluginReward rewardPlugin : rewardPlugins) {
         WalletRewardPluginEntity rewardPluginEntity =
-                                                    rewardPluginDAO.findRewardPluginByRewardIdAndPlugin(rewardEntity.getId(),
+                                                    rewardPluginDAO.getRewardPluginsByRewardIdAndPluginId(rewardEntity.getId(),
                                                                                                         rewardPlugin.getPluginId());
         if (rewardPluginEntity == null) {
           rewardPluginEntity = new WalletRewardPluginEntity();
@@ -216,7 +216,7 @@ public class WalletRewardReportStorage implements RewardReportStorage {
   }
 
   private Set<WalletPluginReward> getRewardPluginsByRewardId(Long rewardId) {
-    List<WalletRewardPluginEntity> rewardsPluginEntities = rewardPluginDAO.findRewardPluginsByPeriodId(rewardId);
+    List<WalletRewardPluginEntity> rewardsPluginEntities = rewardPluginDAO.getRewardPluginsByRewardId(rewardId);
     if (rewardsPluginEntities != null) {
       return rewardsPluginEntities.stream()
                                   .map(entity -> toDTO(entity))

--- a/wallet-reward-services/src/main/resources/conf/portal/wallet-reward-configuration.xml
+++ b/wallet-reward-services/src/main/resources/conf/portal/wallet-reward-configuration.xml
@@ -104,7 +104,7 @@
           <property name="jobName" value="RewardStatusVerifierJob"/>
           <property name="groupName" value="Wallet"/>
           <property name="job" value="org.exoplatform.addon.wallet.reward.job.RewardStatusVerifierJob"/>
-          <property name="expression" value="${exo.addon.wallet.RewardStatusVerifierJob.expression:0 * * * * ?}"/>
+          <property name="expression" value="${exo.wallet.RewardStatusVerifierJob.expression:0 * * * * ?}"/>
         </properties-param>
       </init-params>
     </component-plugin>
@@ -120,7 +120,7 @@
           <property name="jobName" value="RewardCurrentPeriodStatusUpdaterJob"/>
           <property name="groupName" value="Wallet"/>
           <property name="job" value="org.exoplatform.addon.wallet.reward.job.RewardCurrentPeriodStatusUpdaterJob"/>
-          <property name="expression" value="${exo.addon.wallet.RewardCurrentPeriodStatusUpdaterJob.expression:0 0/15 * ? * * *}"/>
+          <property name="expression" value="${exo.wallet.RewardCurrentPeriodStatusUpdaterJob.expression:0 0/15 * ? * * *}"/>
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
This PR will fix retrieving more than one plugin reward from store by adding new query that is used to filter reward plugins by identifier.

In addition, this will change a variable to be uniform with other variables defined in Rewards.