### PR TITLE
PLF-8539 Unable to delete some pools

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/storage/RewardTeamStorage.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/storage/RewardTeamStorage.java
@@ -59,4 +59,12 @@ public interface RewardTeamStorage {
    * @return {@link List} of {@link RewardTeam}
    */
   public List<RewardTeam> findTeamsByMemberId(long identityId);
+
+  /**
+   * Retrieve team identified by its technical id
+   * 
+   * @param teamId team DB ID
+   * @return {@link RewardTeam}
+   */
+  public RewardTeam getTeamsById(long teamId);
 }

--- a/wallet-api/src/main/lombok/org/exoplatform/wallet/model/reward/RewardTeam.java
+++ b/wallet-api/src/main/lombok/org/exoplatform/wallet/model/reward/RewardTeam.java
@@ -37,6 +37,9 @@ public class RewardTeam implements Serializable {
   private boolean                disabled;
 
   @Exclude
+  private boolean                deleted;
+
+  @Exclude
   private RewardTeamMember       manager;
 
   @Exclude

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardTeamDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardTeamDAO.java
@@ -18,4 +18,11 @@ public class RewardTeamDAO extends GenericDAOJPAImpl<RewardTeamEntity, Long> {
     return result == null ? Collections.emptyList() : result;
   }
 
+  public List<RewardTeamEntity> findNotDeletedTeams() {
+    TypedQuery<RewardTeamEntity> query = getEntityManager().createNamedQuery("RewardTeam.findNoDeletedTeams",
+                                                                             RewardTeamEntity.class);
+    List<RewardTeamEntity> result = query.getResultList();
+    return result == null ? Collections.emptyList() : result;
+  }
+
 }

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamEntity.java
@@ -16,7 +16,8 @@ import org.exoplatform.wallet.model.reward.RewardBudgetType;
 @DynamicUpdate
 @Table(name = "ADDONS_WALLET_GAM_TEAM")
 @NamedQueries({
-    @NamedQuery(name = "RewardTeam.findTeamsByMemberId", query = "SELECT rt FROM RewardTeam rt JOIN rt.members mem WHERE mem.identityId = :identityId ORDER BY rt.id DESC"),
+    @NamedQuery(name = "RewardTeam.findNoDeletedTeams", query = "SELECT rt FROM RewardTeam rt WHERE rt.deleted = FALSE ORDER BY rt.id DESC"),
+    @NamedQuery(name = "RewardTeam.findTeamsByMemberId", query = "SELECT rt FROM RewardTeam rt JOIN rt.members mem WHERE rt.deleted = FALSE AND mem.identityId = :identityId ORDER BY rt.id DESC"),
 })
 public class RewardTeamEntity implements Serializable {
 
@@ -48,6 +49,9 @@ public class RewardTeamEntity implements Serializable {
 
   @Column(name = "TEAM_DISABLED")
   private Boolean                     disabled;
+
+  @Column(name = "TEAM_DELETED")
+  private Boolean                     deleted;
 
   @OneToMany(mappedBy = "team", fetch = FetchType.EAGER, cascade = { CascadeType.ALL }, orphanRemoval = true)
   private Set<RewardTeamMemberEntity> members          = new HashSet<>();
@@ -114,6 +118,14 @@ public class RewardTeamEntity implements Serializable {
 
   public void setDisabled(Boolean disabled) {
     this.disabled = disabled;
+  }
+
+  public void setDeleted(Boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  public Boolean getDeleted() {
+    return deleted;
   }
 
   public Set<RewardTeamMemberEntity> getMembers() {

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardTeamService.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardTeamService.java
@@ -61,4 +61,11 @@ public class WalletRewardTeamService implements RewardTeamService {
     return this.rewardTeamStorage.findTeamsByMemberId(identityId);
   }
 
+  public RewardTeam getTeamsById(long teamId) {
+    if (teamId == 0) {
+      throw new IllegalArgumentException("Team id is required");
+    }
+    return this.rewardTeamStorage.getTeamsById(teamId);
+  }
+
 }

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardTeamStorage.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardTeamStorage.java
@@ -44,7 +44,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
 
   @Override
   public List<RewardTeam> getTeams() {
-    List<RewardTeamEntity> teamEntities = rewardTeamDAO.findAll();
+    List<RewardTeamEntity> teamEntities = rewardTeamDAO.findNotDeletedTeams();
     return teamEntities.stream().map(teamEntity -> toDTO(teamEntity)).collect(Collectors.toList());
   }
 
@@ -69,7 +69,8 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
     }
     RewardTeamEntity entity = rewardTeamDAO.find(teamId);
     if (entity != null) {
-      rewardTeamDAO.delete(entity);
+      entity.setDeleted(true);
+      rewardTeamDAO.update(entity);
     }
     return toDTO(entity);
   }
@@ -89,6 +90,12 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
     return entities.stream().map(team -> toDTO(team)).collect(Collectors.toList());
   }
 
+  @Override
+  public RewardTeam getTeamsById(long teamId) {
+    RewardTeamEntity teamEntity = rewardTeamDAO.find(teamId);
+    return toDTO(teamEntity);
+  }
+
   private static RewardTeamEntity fromDTO(RewardTeam rewardTeam) {
     if (rewardTeam == null) {
       return null;
@@ -100,6 +107,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
     teamEntity.setBudget(rewardTeam.getBudget());
     teamEntity.setRewardType(rewardTeam.getRewardType());
     teamEntity.setDisabled(rewardTeam.isDisabled());
+    teamEntity.setDeleted(rewardTeam.isDeleted());
     if (rewardTeam.getManager() != null && rewardTeam.getManager().getIdentityId() != 0) {
       teamEntity.setManager(rewardTeam.getManager().getIdentityId());
     }
@@ -128,6 +136,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
     rewardTeam.setManager(getRewardTeamMember(teamEntity.getManager()));
     rewardTeam.setRewardType(teamEntity.getRewardType());
     rewardTeam.setDisabled(teamEntity.getDisabled());
+    rewardTeam.setDeleted(teamEntity.getDeleted());
     if (teamEntity.getSpaceId() != null && teamEntity.getSpaceId() != 0) {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       Space space = spaceService.getSpaceById(String.valueOf(teamEntity.getSpaceId()));

--- a/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
@@ -143,4 +143,10 @@
     </sql>
   </changeSet>
 
+  <changeSet author="reward" id="1.0.0-11">
+    <addColumn tableName="ADDONS_WALLET_GAM_TEAM">
+      <column name="TEAM_DELETED" type="BOOLEAN" defaultValueBoolean="false" />
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/test/service/WalletRewardTeamServiceTest.java
+++ b/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/test/service/WalletRewardTeamServiceTest.java
@@ -67,12 +67,16 @@ public class WalletRewardTeamServiceTest extends BaseWalletRewardTest {
     RewardTeam rewardTeam = newRewardTeam();
 
     rewardTeam = rewardTeamService.saveTeam(rewardTeam);
+    assertFalse(rewardTeam.isDeleted());
     List<RewardTeam> teams = rewardTeamService.getTeams();
     assertEquals(1, teams.size());
 
     rewardTeamService.removeTeam(rewardTeam.getId());
     teams = rewardTeamService.getTeams();
     assertEquals(0, teams.size());
+
+    rewardTeam = rewardTeamService.getTeamsById(rewardTeam.getId());
+    assertTrue(rewardTeam.isDeleted());
   }
 
 }


### PR DESCRIPTION
The pools can't be deleted when Rewards was sent or estimated using the pool. Thus, we should keep the pool in the database and just mark it as deleted in order to keep history of rewards sent.

